### PR TITLE
Replace unsupported DatastoreProfileTDEngine in python 3.11 with DatastoreProfilePostgreSQL

### DIFF
--- a/llm-monitoring-main.ipynb
+++ b/llm-monitoring-main.ipynb
@@ -19,6 +19,10 @@
     "\n",
     "This notebook guides you through setting up an effective model monitoring system that leverages LLMs (LLM as a Judge) to maintain high standards for deployed models. It demonstrates how to prepare and evaluate a good prompt for the LLM judge, deploy model monitoring applications, assess the performance of a pre-trained model, fine-tune it using the ORPO technique on the supplied dataset, show the monitoring results for the fine-tuned model and finally, set an automatic pipeline to automatically fine-tune the model once the monitor raised an alert.\n",
     "\n",
+    "### Note: in order to run this notebook you have to provide PostgreSQL\n",
+    "\n",
+    "\n",
+    "\n",
     "![](./images/feedback_loop.png)"
    ]
   },

--- a/llm-monitoring-main.ipynb
+++ b/llm-monitoring-main.ipynb
@@ -22,7 +22,6 @@
     "### Note: in order to run this notebook you have to provide PostgreSQL\n",
     "\n",
     "\n",
-    "\n",
     "![](./images/feedback_loop.png)"
    ]
   },

--- a/src/model_monitoring_utils.py
+++ b/src/model_monitoring_utils.py
@@ -3,7 +3,7 @@ import os
 import mlrun
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileKafkaSource,
-    DatastoreProfileTDEngine,
+    DatastoreProfilePostgreSQL,
     DatastoreProfileV3io,
 )
 
@@ -24,12 +24,13 @@ def enable_model_monitoring(
 
     if mlrun.mlconf.is_ce_mode():
         mlrun_namespace = os.environ.get("MLRUN_NAMESPACE", "mlrun")
-        tsdb_profile = DatastoreProfileTDEngine(
+        tsdb_profile = DatastoreProfilePostgreSQL(
             name=tsdb_profile_name,
-            user="root",
-            password="taosdata",
-            host=f"tdengine-tsdb.{mlrun_namespace}.svc.cluster.local",
-            port="6041",
+            user="postgres",
+            password="password",
+            host=f"timescaledb.{mlrun_namespace}.svc.cluster.local",
+            port="5432",
+            database="mlrun",
         )
 
         stream_profile = DatastoreProfileKafkaSource(


### PR DESCRIPTION
Replace unsupported DatastoreProfileTDEngine in python 3.11 with DatastoreProfilePostgreSQL